### PR TITLE
fix LiveContainer/LiveContainer#1489: LiveContainer built-in SideStore strips .xctest bundles from imported XCTest runner apps

### DIFF
--- a/AltStore/Operations/ResignAppOperation.swift
+++ b/AltStore/Operations/ResignAppOperation.swift
@@ -172,9 +172,10 @@ final class ResignAppOperation: ResultOperation<ALTApplication>, OperationLoggin
         
         if let directory = appBundle.builtInPlugInsURL, let enumerator = FileManager.default.enumerator(at: directory, includingPropertiesForKeys: nil, options: [.skipsSubdirectoryDescendants]) {
             for case let fileURL as URL in enumerator {
-                // for both sim and device, in debug mode builds, remove the tests bundles (if any)
+                // Only strip SideStore's own debug test products. Imported XCTest runners need their .xctest bundle at runtime.
                 #if DEBUG
-                guard !fileURL.lastPathComponent.lowercased().contains(".xctest") else {
+                let isOwnTestArtifact = app.isAltStoreApp && fileURL.pathExtension.lowercased() == "xctest"
+                if isOwnTestArtifact {
                     // Remove embedded XCTest (+ dSYM) bundle from copied app bundle.
                     try FileManager.default.removeItem(at: fileURL)
                     continue


### PR DESCRIPTION
### Description of Changes
fix https://github.com/LiveContainer/LiveContainer/issues/1489

### Rationale behind Changes
* Preserve and resign .xctest bundles contained in imported apps.
* Allow XCTest runner apps such as WebDriverAgent to launch normally.
* If SideStore still needs to remove its own test artifacts, restrict that cleanup to SideStore itself instead of applying it to every imported app.

### Suggested Testing Steps
1. Install iLoader stable 2.2.10.
2. In iLoader, install custom built LiveContainer+SideStore
3. Open LiveContainer's built-in SideStore.
4. Import and install a WebDriverAgent runner IPA prepared from [Appium WebDriverAgent 15.1.6](https://github.com/appium/WebDriverAgent/releases/tag/v15.1.6).
5. Before installation, verify that the input IPA contains:
Payload/WebDriverAgentRunner-Runner.app/
└── PlugIns/
    └── WebDriverAgentRunner.xctest/

6. Start the installed XCTest runner:

./idevice-tools \
  --udid 00008110-0009346E21F3801E \
  xctest com.facebook.WebDriverAgentRunner.xctrunner.5FL5S3NZWJ

The runner process initially becomes ready, and XCTest bootstrap without issue:
```
[XCTest] Runner:  com.facebook.WebDriverAgentRunner.xctrunner.5FL5S3NZWJ
[XCTest] App path:      /private/var/containers/Bundle/Application/26554D44-1ECB-4597-AF43-376360ABDF66/App.app
[XCTest] Container:     /private/var/mobile/Containers/Data/Application/71480A28-461F-42F8-806F-33013163807B
[XCTest] Executable:    WebDriverAgentRunner-Runner
[XCTest] Launching runner - this may take 15-30s ...
[XCTest] Runner ready. Automation session is live.
[XCTest] WDA device-side ports follow USE_PORT and MJPEG_SERVER_PORT from --env.
[XCTest] Test plan started
[XCTest]   CASE START: /
```

### Did you use AI to help find, test, or implement this issue or feature?
yes, but i build and tested on my own
