### PR TITLE
fix(connectivity): integrate protocol-aware heartbeat sessions

### DIFF
--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -181,6 +181,10 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationDidBecomeActive(_ application: UIApplication)
     {
+        Task {
+            await revalidateMinimuxerConnectivityAfterForeground()
+        }
+
         // Flush any .ipa import that arrived before the app was active (cold launch).
         guard let url = self.pendingImportIPAURL else { return }
         self.pendingImportIPAURL = nil

--- a/AltStore/Settings/HealthCheckView.swift
+++ b/AltStore/Settings/HealthCheckView.swift
@@ -97,7 +97,6 @@ final class HealthCheckViewModel: ObservableObject {
         let overrideEffective = TunnelConfig.shared.overrideEffective
         
         let pairingType = Minimuxer.shared.getPairingFileType()
-        let isRp = pairingType == .rppairing
         let protocolStr: String
         switch pairingType {
         case .rppairing:
@@ -472,7 +471,7 @@ struct HealthCheckView: View {
                     isSatisfied: viewModel.ddiSatisfied
                 )
             }
-            
+
             // Section 3: Discovered Configs
             Section(header: Text("VPN IP Configuration")) {
                 ConfigRow(label: "Tunnel Iface IP", value: viewModel.tunnelIfaceIp)

--- a/SideStore/MinimuxerWrapper.swift
+++ b/SideStore/MinimuxerWrapper.swift
@@ -114,6 +114,12 @@ func minimuxerStart(_ pairingFile: String, mountPath: String) async throws {
     #endif
 }
 
+func revalidateMinimuxerConnectivityAfterForeground() async {
+    #if !targetEnvironment(simulator)
+    await Minimuxer.shared.revalidateConnectivitySessionAfterForeground()
+    #endif
+}
+
 
 func reinitializePairingData(pairingFile: String) async throws {
     defer { debugLog("[SideStore] reinitializePairingData(pairingFile) completed") }


### PR DESCRIPTION
## Summary

Integrate the protocol-aware heartbeat and DDI readiness lifecycle from LiveContainer/minimuxer#1 into SideStore.

The change stabilizes Lockdown Health Check, DDI mounting, and profile operations while preserving the existing Remote Pairing/RSD behavior. The temporary A/B UI and legacy A path are not included; production uses the final protocol-aware behavior directly.

## Changes

- Update the minimuxer submodule from `1abc888a` to `1d43db60`.
- Revalidate the active minimuxer connectivity session whenever SideStore becomes active.
- Route foreground revalidation through the SideStore minimuxer wrapper.
- Remove an obsolete Health Check pairing-mode local left by the earlier experiment.

## Dependency

Depends on LiveContainer/minimuxer#1.

The submodule must continue to reference the final minimuxer commit after that PR is merged. If the minimuxer PR is squash-merged, this PR will need a final submodule SHA update.

## Resulting behavior

| Pairing mode | Heartbeat | Startup DDI |
| --- | --- | --- |
| Lockdown | Persistent session heartbeat; Ready after Marco/Polo | Waits for the current session to become Ready |
| Remote Pairing | No Lockdown heartbeat | Preserves the existing RSD flow without a heartbeat gate |

## Validation

Manually passed on physical iPhone 13 devices:

- iOS 16.0.2 using Lockdown
- iOS 17.5.1 using Remote Pairing/RSD
- Health Check remained stable during a 60-second observation
- DDI recognition and application refresh/install completed successfully
- No `Heartbeat(Timeout)`, `UnexpectedEof`, `ImageMountFailed`, or transient `dmg=false` was observed during the final Lockdown validation

Automated minimuxer validation: `swift test` passed 14 tests with 0 failures.